### PR TITLE
Support plaintext responses

### DIFF
--- a/render/engine.go
+++ b/render/engine.go
@@ -48,14 +48,14 @@ func (e Engine) BuildRenderNode() tree.TraversalFunc {
 			templateFile = "openapi.tmpl"
 		case *path.Item:
 			templateFile = "path_item.tmpl"
+		case *operation.Operation:
+			templateFile = "operation.tmpl"
 		case *schema.Schema:
 			schemaType := node.(*schema.Schema).Type
 			if schemaType != "object" && schemaType != "array" {
 				return node, nil
 			}
 			templateFile = "schema.tmpl"
-		case *operation.Operation:
-			templateFile = "operation.tmpl"
 		}
 
 		if templateFile == "" {

--- a/templates/go-gin/operation.tmpl
+++ b/templates/go-gin/operation.tmpl
@@ -95,5 +95,3 @@ func (*{{ .RequestBody.GetName | SanitiseName }}) IsValid() (bool, error) {
 }
 {{- end }}
 
-
-

--- a/templates/go-gin/operation.tmpl
+++ b/templates/go-gin/operation.tmpl
@@ -2,6 +2,8 @@
 
 package {{ index .GetMetadata "package" }}
 
+import "github.com/gin-gonic/gin"
+
 {{- $needs_fmt := false }}
 {{- $needs_regexp := false }}
 
@@ -95,3 +97,26 @@ func (*{{ .RequestBody.GetName | SanitiseName }}) IsValid() (bool, error) {
 }
 {{- end }}
 
+type {{ .GetName | SanitiseName }}Response interface {
+	Send(c *gin.Context)
+}
+
+{{- range $name, $response := .Responses }}
+{{ $statusCode := $name }}
+{{- range $name, $content := $response.Content }}
+type {{ $response.GetName | SanitiseName }} {{ $content.Schema.GetName | SanitiseName }}
+
+func (r {{ $response.GetName | SanitiseName }}) Send(c *gin.Context) {
+	{{- if eq $name "application/json" }}
+	c.JSON({{ $statusCode }}, r)
+	{{- else if eq $name "text/plain" }}
+	c.String({{ $statusCode }}, fmt.Sprint(r))
+	{{- end }}
+}
+{{- end }}
+{{- end }}
+
+type {{ .GetName | SanitiseName }}405Response struct {}
+func (r {{ .GetName | SanitiseName }}405Response) Send(c *gin.Context) {
+	c.JSON(405, r)
+}

--- a/templates/go-gin/operation.tmpl
+++ b/templates/go-gin/operation.tmpl
@@ -3,26 +3,23 @@
 package {{ index .GetMetadata "package" }}
 
 import "github.com/gin-gonic/gin"
+import "fmt"
 
-{{- $needs_fmt := false }}
 {{- $needs_regexp := false }}
 
 {{- range $i, $parameter := .Parameters }}
-{{- if ne $parameter.Schema.MinLength 0 }}{{ $needs_fmt = true }}{{- end }}
-{{- if ne $parameter.Schema.MaxLength 0 }}{{ $needs_fmt = true }}{{- end }}
 {{- if ne $parameter.Schema.Pattern "" }}{{ $needs_regexp = true }}{{- end }}
 {{- end }}
 
 {{- range $name, $requestBody := .RequestBody.Content }}
 {{- range $name, $property := $requestBody.Schema.Properties }}
-{{- if ne $property.MinLength 0 }}{{ $needs_fmt = true}}{{- end }}
-{{- if ne $property.MaxLength 0 }}{{ $needs_fmt = true}}{{- end }}
 {{- if ne $property.Pattern "" }}{{ $needs_regexp = true }}{{- end }}
 {{- end }}
 {{- end }}
 
-{{ if $needs_fmt -}} import "fmt" {{- end }}
 {{ if $needs_regexp -}} import "regexp" {{- end }}
+
+var _ = fmt.Sprint("")
 
 type {{ .GetName | SanitiseName }}Parameters struct {
 {{- range $i, $parameter := .Parameters }}
@@ -103,6 +100,19 @@ type {{ .GetName | SanitiseName }}Response interface {
 
 {{- range $name, $response := .Responses }}
 {{ $statusCode := $name }}
+
+{{- if not .Content }}
+type {{ .GetName | SanitiseName }} struct {}
+
+func (*{{ .GetName | SanitiseName }}) IsValid() (bool, error) {
+	return true, nil
+}
+
+func (r {{ .GetName | SanitiseName }}) Send(c *gin.Context) {
+	c.String({{ $statusCode }}, fmt.Sprint(r))
+}
+{{- end }}
+
 {{- range $name, $content := $response.Content }}
 type {{ $response.GetName | SanitiseName }} {{ $content.Schema.GetName | SanitiseName }}
 

--- a/templates/go-gin/path_item.tmpl
+++ b/templates/go-gin/path_item.tmpl
@@ -57,14 +57,14 @@ func Register{{ .GetName | SanitiseName }}Path(e gin.IRouter, srv {{ .GetName | 
 			return
     }
     response := srv.{{ $operation.GetName | SanitiseName }}(c, params, body)
-    c.JSON(response.GetStatus(), response)
+    response.Send(c)
   })
 {{- end }}
 }
 
 {{- range $name, $operation := .Operations }}
 type {{ $operation.GetName | SanitiseName }}Response interface {
-	GetStatus() int
+	Send(c *gin.Context)
 }
 
 {{- range $name, $response := .Responses }}
@@ -72,14 +72,18 @@ type {{ $operation.GetName | SanitiseName }}Response interface {
 {{- range $name, $content := $response.Content }}
 type {{ $response.GetName | SanitiseName }} {{ $content.Schema.GetName | SanitiseName }}
 
-func ({{ $response.GetName | SanitiseName }}) GetStatus() int {
-	return {{ $statusCode }}
+func (r {{ $response.GetName | SanitiseName }}) Send(c *gin.Context) {
+	{{- if eq $name "application/json" }}
+	c.JSON({{ $statusCode }}, r)
+	{{- else if eq $name "text/plain" }}
+	c.String({{ $statusCode }}, fmt.Sprint(r))
+	{{- end }}
 }
 {{- end }}
 {{- end }}
 type {{ $operation.GetName | SanitiseName }}405Response struct {}
-func ({{ $operation.GetName | SanitiseName }}405Response) GetStatus() int {
-	return 405
+func (r {{ $operation.GetName | SanitiseName }}405Response) Send(c *gin.Context) {
+	c.JSON(405, r)
 }
 
 {{- end }}

--- a/templates/go-gin/path_item.tmpl
+++ b/templates/go-gin/path_item.tmpl
@@ -61,29 +61,3 @@ func Register{{ .GetName | SanitiseName }}Path(e gin.IRouter, srv {{ .GetName | 
   })
 {{- end }}
 }
-
-{{- range $name, $operation := .Operations }}
-type {{ $operation.GetName | SanitiseName }}Response interface {
-	Send(c *gin.Context)
-}
-
-{{- range $name, $response := .Responses }}
-{{ $statusCode := $name }}
-{{- range $name, $content := $response.Content }}
-type {{ $response.GetName | SanitiseName }} {{ $content.Schema.GetName | SanitiseName }}
-
-func (r {{ $response.GetName | SanitiseName }}) Send(c *gin.Context) {
-	{{- if eq $name "application/json" }}
-	c.JSON({{ $statusCode }}, r)
-	{{- else if eq $name "text/plain" }}
-	c.String({{ $statusCode }}, fmt.Sprint(r))
-	{{- end }}
-}
-{{- end }}
-{{- end }}
-type {{ $operation.GetName | SanitiseName }}405Response struct {}
-func (r {{ $operation.GetName | SanitiseName }}405Response) Send(c *gin.Context) {
-	c.JSON(405, r)
-}
-
-{{- end }}


### PR DESCRIPTION
This pull request adds support for text/plain content types in go-gin generated servers.
It also moves some of the templating in the go-gin server templates to more appropriate locations to enhance clarity and readability.