### PR TITLE
fix path param formatting in server templates

### DIFF
--- a/render/engine_test.go
+++ b/render/engine_test.go
@@ -5,12 +5,8 @@ import (
 	golang "github.com/sasswart/gin-in-a-can/render/go"
 	"github.com/sasswart/gin-in-a-can/test"
 	"github.com/sasswart/gin-in-a-can/tree"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 	"os"
-	"strings"
 	"testing"
-	"text/template"
 )
 
 func Test_Render_Render(t *testing.T) {
@@ -31,15 +27,7 @@ func Test_Render_Render(t *testing.T) {
 	cfg.OutputPath = tempFolder
 	e := render.Engine{}.With(&golang.Renderer{Base: &render.Base{}}, cfg)
 	r := *e.GetRenderer()
-	r.SetTemplateFuncMap(&template.FuncMap{
-		"ToUpper": strings.ToUpper,
-		"ToTitle": func(s string) string {
-			caser := cases.Title(language.English)
-			return caser.String(s)
-		},
-		"SanitiseName": r.SanitiseName,
-		"SanitiseType": r.SanitiseType,
-	})
+	r.SetTemplateFuncMap(nil)
 	if r.GetTemplateFuncMap() == nil {
 		t.Errorf("TemplateFuncMap should NOT be nil")
 	}

--- a/render/go/renderer.go
+++ b/render/go/renderer.go
@@ -29,6 +29,9 @@ func (g *Renderer) SetTemplateFuncMap(f *template.FuncMap) {
 	g.Base.SetTemplateFuncMap(&template.FuncMap{
 		"ToUpper": strings.ToUpper,
 		"ToTitle": ToTitle,
+		"StringsReplace": func(input, from, to string) string {
+			return strings.Replace(input, from, to, -1)
+		},
 		// TODO this should NOT be self-referential
 		"SanitiseName": g.SanitiseName,
 		"SanitiseType": g.SanitiseType,

--- a/templates/go-gin/path_item.tmpl
+++ b/templates/go-gin/path_item.tmpl
@@ -28,8 +28,15 @@ func (u {{ $pathItemStructName }}) InvalidRequest(c *gin.Context, err error) {
 
 func Register{{ .GetName | SanitiseName }}Path(e gin.IRouter, srv {{ .GetName | SanitiseName }}) {
 {{- range $name, $operation := .Operations }}
-	{{ $parent := .GetParent }}
-  e.{{ $name | ToUpper }}("{{ $parent.Name }}", func(c *gin.Context) {
+	{{ $path := .GetParent.Name }}
+	{{- range $i, $parameter := $operation.Parameters}}
+        {{- if eq ($parameter.In | ToTitle) ("path" | ToTitle) }}
+            {{ $from := printf "{%s}" $parameter.ParamName }}
+            {{ $to := printf ":%s" $parameter.ParamName }}
+            {{ $path = StringsReplace $path $from $to }}
+    	{{- end }}
+	{{- end }}
+  e.{{ $name | ToUpper }}("{{ $path }}", func(c *gin.Context) {
   	params := &{{ $operation.GetName | SanitiseName }}Parameters{}
     {{- range $param := $operation.Parameters }}
 		params.{{ $param.GetParamName | SanitiseName }} =


### PR DESCRIPTION
This will allow us to create gin-compliant path strings for the gin engine to match against while allowing us to retain full compliancy with regards to how those path strings have to be formatted for openapi 3.0.0