### PR TITLE
Clean automatically generated version string

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Show go version
         run: go version
       - name: Generate build files
-        run: make VERSION='${{ github.ref }}' all
+        run: make VERSION='${{ github.head_ref }}' all
       - name: Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Show go version
         run: go version
       - name: Generate build files
-        run: make VERSION='${{ github.head_ref }}' all
+        run: make VERSION='${{ github.ref_name }}' all
       - name: Release
         uses: softprops/action-gh-release@v1
         with:

--- a/cmd/can/main.go
+++ b/cmd/can/main.go
@@ -13,6 +13,7 @@ import (
 var Renderer *render.Engine
 
 func main() {
+	fmt.Printf("can %s\n", config.SemVer)
 	cfg := config.Data{}
 	err := cfg.Load()
 	if err != nil {


### PR DESCRIPTION
Our version string has a github ref path included. 
This PR will remove all but the version identifier and allocate it to the current global that stores it. 