### PR TITLE
go-client bugfixes

### DIFF
--- a/templates/go-client/openapi.tmpl
+++ b/templates/go-client/openapi.tmpl
@@ -27,7 +27,7 @@ var _ ClientService = &Client{}
 type AuthFunc func(*http.Request) error
 
 type Config struct {
-	Port string `validate:"required,hostname_port"`
+	Port string `validate:"hostname_port"`
 	Host string `validate:"required,hostname"` // Hostname RFC 952
 	Protocol string `validate:"required"`
 	ContentType string `validate:"required"`

--- a/templates/go-client/path_item.tmpl
+++ b/templates/go-client/path_item.tmpl
@@ -1,9 +1,13 @@
 package {{ index .GetMetadata "package" }}
 {{- $pathParamPresent := false}}
 {{- $postMethodPresent := false}}
+{{- $patchMethodPresent := false}}
 {{- range $name, $operation := .Operations }}
     {{- if eq $operation.Name "POST" }}
         {{- $postMethodPresent = true }}
+    {{- end }}
+    {{- if eq $operation.Name "PATCH" }}
+        {{- $patchMethodPresent = true }}
     {{- end }}
 	{{- range $param := $operation.Parameters }}
     {{- if eq ($param.In | ToTitle) "Path" }}
@@ -12,11 +16,11 @@ package {{ index .GetMetadata "package" }}
     {{- end }}
 {{- end }}
 import (
-{{ if $postMethodPresent }}
+{{- if or $postMethodPresent $patchMethodPresent }}
     "bytes"
 {{- end }}
 	"context"
-{{ if $postMethodPresent }}
+{{- if or $postMethodPresent $patchMethodPresent }}
     "encoding/json"
 {{- end }}
 	"errors"
@@ -24,7 +28,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-{{ if $pathParamPresent }}
+{{- if $pathParamPresent }}
 	"strings"
 {{- end }}
 
@@ -38,7 +42,7 @@ func (c *Client) {{ $operation.GetName | SanitiseName }}(ctx context.Context, pa
         ctx = context.Background()
     }
     var payload io.Reader = nil
-    {{- if eq $operation.Name "POST" }}
+    {{- if or (eq $operation.Name "POST") (eq $operation.Name "PATCH") }}
     if body != nil {
         data, err := json.Marshal(body)
         if err != nil { // This serves as our validation, for now
@@ -46,7 +50,7 @@ func (c *Client) {{ $operation.GetName | SanitiseName }}(ctx context.Context, pa
         }
         payload = bytes.NewReader(data)
     } else {
-        return nil, errors.New("(c *Client) {{ $operation.OperationId }} :: post operation with nil body")
+        return nil, errors.New("(c *Client) {{ $operation.OperationId }} :: post or patch operation with nil body")
     }
     {{- end }}
     var vals url.Values


### PR DESCRIPTION
This PR allows us to omit the port when creating clients as well as fixes a bug where go-client clients were not able to send their patch body along with requests