### PR TITLE
allow for optional boolean fields in requests and responses

### DIFF
--- a/templates/go-client/schema.tmpl
+++ b/templates/go-client/schema.tmpl
@@ -11,7 +11,17 @@ type {{ .GetName | SanitiseName }} {{ . | SanitiseType }}
         {{ if eq ($schema | SanitiseType) "struct" -}}
             {{ $name | ToTitle }} {{ $schema.GetName | SanitiseName }}
         {{- else -}}
-            {{ $name | ToTitle }} {{ $schema | SanitiseType }} `json:"{{ $name }}"`
+            {{- $required := false }}
+            {{- range $requiredProperty := $schema.Required }}
+                {{- if eq $name $requiredProperty }}
+                    {{- $required = true }}
+                {{- end }}
+            {{- end }}
+            {{- if eq $required false -}}
+                {{ $name | ToTitle }}  {{ if eq ($schema | SanitiseType) "bool" }}*{{ end }}{{ $schema | SanitiseType }} `json:"{{ $name }},omitempty"`
+            {{- else }}
+                {{ $name | ToTitle }} {{ $schema | SanitiseType }} `json:"{{ $name }}"`
+            {{- end }}
         {{- end }}
 	{{- end }}
 }


### PR DESCRIPTION
This PR will allow us to generate go clients that respect the optional boolean parameter by using a boolean pointer in the go code generated. This will allow consumers of these clients to set the enabled pointer to nil where it's optional, effectively omitting their addition to the optional boolean field in the request/ 