### PR TITLE
Further Refactor

### DIFF
--- a/cmd/can/main.go
+++ b/cmd/can/main.go
@@ -44,7 +44,7 @@ func main() {
 		"package": cfg.Template.BasePackageName,
 	})
 
-	_, err = tree.Traverse(apiSpec, engine.BuildRenderNode())
+	_, err = tree.Traverse(apiSpec, engine.Render)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)

--- a/cmd/can/main.go
+++ b/cmd/can/main.go
@@ -12,43 +12,43 @@ import (
 
 func main() {
 	fmt.Printf("can %s\n", config.SemVer)
-	// TODO: MustLoadConfig
-	cfg := config.Data{}
-	err := cfg.Load()
-	if err != nil {
-		fmt.Println(err.Error())
-		os.Exit(1)
-	}
+	cfg := mustLoadConfig()
 	if config.Debug {
 		fmt.Printf("Reading API specification from \"%s\"\n", cfg.GetOpenAPIFilepath())
 	}
-	// TODO: What if JSON?
-	// TODO: MustLoadOpenApiFile
-	apiSpec, err := openapi.LoadFromYaml(cfg.GetOpenAPIFilepath())
-	if err != nil {
-		fmt.Println(err.Error())
-		os.Exit(1)
-	}
+	apiSpec := mustLoadOpenApiFile(cfg.GetOpenAPIFilepath())
 
 	engine := render.NewEngine(cfg)
 
 	// Setup appropriate renderer via the `strategy` design pattern
-	// TODO: MustSetStrategy
-	err = setStrategy(engine, cfg.Template.Strategy)
-	if err != nil {
-		fmt.Println(err.Error())
-		os.Exit(1)
-	}
+	mustSetStrategy(engine, cfg.Template.Strategy)
 
 	apiSpec.SetMetadata(tree.Metadata{
 		"package": cfg.Template.BasePackageName,
 	})
 
-	_, err = tree.Traverse(apiSpec, engine.Render)
+	if _, err := tree.Traverse(apiSpec, engine.Render); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+}
+
+func mustSetStrategy(engine render.Engine, strategy string) {
+	err := setStrategy(engine, strategy)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}
+}
+
+func mustLoadOpenApiFile(path string) *openapi.OpenAPI {
+	// TODO: What if JSON?
+	apiSpec, err := openapi.LoadFromYaml(path)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	return apiSpec
 }
 
 // setStrategy creates and applies the renderer for the given strategy. An error is returned if the strategy is invalid
@@ -62,4 +62,14 @@ func setStrategy(e render.Engine, strategy string) error {
 		return nil
 	}
 	return fmt.Errorf("%s render strategy not implemented yet", strategy)
+}
+
+func mustLoadConfig() config.Data {
+	cfg := config.Data{}
+	err := cfg.Load()
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	return cfg
 }

--- a/cmd/can/main.go
+++ b/cmd/can/main.go
@@ -12,6 +12,7 @@ import (
 
 func main() {
 	fmt.Printf("can %s\n", config.SemVer)
+	// TODO: MustLoadConfig
 	cfg := config.Data{}
 	err := cfg.Load()
 	if err != nil {
@@ -21,15 +22,19 @@ func main() {
 	if config.Debug {
 		fmt.Printf("Reading API specification from \"%s\"\n", cfg.GetOpenAPIFilepath())
 	}
+	// TODO: What if JSON?
+	// TODO: MustLoadOpenApiFile
 	apiSpec, err := openapi.LoadFromYaml(cfg.GetOpenAPIFilepath())
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}
 
-	e := render.NewEngine().With(cfg)
+	engine := render.NewEngine(cfg)
+
 	// Setup appropriate renderer via the `strategy` design pattern
-	err = setStrategy(e, cfg.Template.Strategy)
+	// TODO: MustSetStrategy
+	err = setStrategy(engine, cfg.Template.Strategy)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
@@ -39,12 +44,14 @@ func main() {
 		"package": cfg.Template.BasePackageName,
 	})
 
-	_, err = tree.Traverse(apiSpec, e.BuildRenderNode())
+	_, err = tree.Traverse(apiSpec, engine.BuildRenderNode())
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}
 }
+
+// setStrategy creates and applies the renderer for the given strategy. An error is returned if the strategy is invalid
 func setStrategy(e render.Engine, strategy string) error {
 	var r render.Renderer
 	switch strategy {

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 //go:embed version.txt
 var SemVer string
 
+// TODO: move these flags into the config and embed the config into the renderer/engine where needed in order to expose them.
 var (
 	Debug          bool
 	Dryrun         bool

--- a/config/config.go
+++ b/config/config.go
@@ -121,7 +121,7 @@ func (d *Data) Load() (err error) {
 	return nil
 }
 
-func (d *Data) GetTemplateFilesDir() (path string) {
+func (d *Data) GetTemplateFilesDir() string {
 	if d.Template.absDirectory != "" {
 		return d.Template.absDirectory
 	}
@@ -132,10 +132,21 @@ func (d *Data) GetTemplateFilesDir() (path string) {
 	case filepath.IsAbs(ConfigFilePath):
 		d.Template.absDirectory = filepath.Join(filepath.Dir(ConfigFilePath), d.TemplatesDir, d.Template.Name)
 		return d.Template.absDirectory
-
 	// No absolute dir provided. Let's build one
 	default:
 		d.Template.absDirectory = filepath.Join(ProcWorkingDir, filepath.Dir(ConfigFilePath), d.TemplatesDir, d.Template.Name)
+		if filepath.IsAbs(d.Template.absDirectory) {
+			if _, err := os.Stat(d.Template.absDirectory); err == nil {
+				return d.Template.absDirectory
+			}
+		}
+		// TODO: use this method to validate all paths returned
+		var err error
+		d.Template.absDirectory, err = filepath.Abs(d.TemplatesDir)
+		if err != nil {
+			// TODO: don't panic
+			panic("could not find template dir")
+		}
 		return d.Template.absDirectory
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // FYI - if your tests are utilizing flags from os.Args, flags are likely to be redefined through the
-// config.Data{}.LoadFromBytes() method. This will cause test suites to panic!
+// config.Data{}.loadFromBytes() method. This will cause test suites to panic!
 func TestConfig_Load(t *testing.T) {
 	absTestTemplateDir, err := filepath.Abs(filepath.Join("../", testTemplateDir))
 	if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // FYI - if your tests are utilizing flags from os.Args, flags are likely to be redefined through the
-// config.Data{}.Load() method. This will cause test suites to panic!
+// config.Data{}.LoadFromBytes() method. This will cause test suites to panic!
 func TestConfig_Load(t *testing.T) {
 	absTestTemplateDir, err := filepath.Abs(filepath.Join("../", testTemplateDir))
 	if err != nil {

--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -55,16 +55,18 @@ func (o *OpenAPI) SetChild(i string, child tree.NodeTraverser) {
 	errors.CastFail("(o *OpenAPI) setChild", "NodeTraverser", "*schema.Schema")
 }
 
-// LoadFromYaml expects an absolute path. It will unmarshal the yaml file and resolve the references contained within.
+// LoadFromYaml expects a path to an openapi file in yaml format. It will unmarshal the yaml file and resolve the
+// references contained within.
 func LoadFromYaml(openApiFilepath string) (*OpenAPI, error) {
 	// Read yaml file
+	// TODO: should this function have to perform file IO?
 	content, err := os.ReadFile(openApiFilepath)
 	if err != nil {
 		return nil, fmt.Errorf("LoadFromYaml:: unable to read file \"%s\": %w", openApiFilepath, err)
 	}
 
 	api := NewBaseOpenApi()
-	if err := api.Load(content); err != nil {
+	if err := api.LoadFromBytes(content); err != nil {
 		return nil, err
 	}
 	// Resolve references
@@ -74,8 +76,11 @@ func LoadFromYaml(openApiFilepath string) (*OpenAPI, error) {
 	return &api, err
 }
 
+// ResolveReferences traverses the entire openapi struct tree and loads te h
+// TODO: this doesn't have to be public
 func (o *OpenAPI) ResolveReferences(absoluteBasePath string) error {
 	o.SetBasePath(filepath.Dir(absoluteBasePath))
+	// TODO: what if JSON?
 	o, err := tree.Traverse(o, tree.ResolveRefs)
 	if err != nil {
 		return fmt.Errorf("tree traversal error: %w", err)
@@ -83,8 +88,9 @@ func (o *OpenAPI) ResolveReferences(absoluteBasePath string) error {
 	return nil
 }
 
-// Load loads the yaml content into the OpenAPI struct. Extraneous functions that aid in this process should live here.
-func (o *OpenAPI) Load(content []byte) error {
+// LoadFromBytes loads the content into an OpenAPI struct. Extraneous functions that aid in this process should live here.A
+// TODO: this doesn't have to be public
+func (o *OpenAPI) LoadFromBytes(content []byte) error {
 	err := yaml.Unmarshal(content, o)
 	if err != nil {
 		return fmt.Errorf("yaml unmarshalling error: %w", err)
@@ -93,6 +99,7 @@ func (o *OpenAPI) Load(content []byte) error {
 	return nil
 }
 
+// TODO: this doesn't have to be public
 func NewBaseOpenApi() OpenAPI {
 	return OpenAPI{
 		Node: tree.Node{},

--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -24,7 +24,7 @@ type ExternalDocs struct {
 // OpenAPI is a programmatic representation of the OpenApi Document object defined here: https://swagger.io/specification/#openapi-object
 type OpenAPI struct {
 	tree.Node
-	OpenAPI    string `yaml:"openapi"` // TODO it's unclear what this refers to
+	OpenAPI    string `yaml:"openapi"`
 	Info       info.Info
 	Servers    []servers.Server
 	Paths      map[string]*path.Item
@@ -65,20 +65,19 @@ func LoadFromYaml(openApiFilepath string) (*OpenAPI, error) {
 		return nil, fmt.Errorf("LoadFromYaml:: unable to read file \"%s\": %w", openApiFilepath, err)
 	}
 
-	api := NewBaseOpenApi()
-	if err := api.LoadFromBytes(content); err != nil {
+	api := newBaseOpenApi()
+	if err := api.loadFromBytes(content); err != nil {
 		return nil, err
 	}
 	// Resolve references
-	if err := api.ResolveReferences(openApiFilepath); err != nil {
+	if err := api.resolveReferences(openApiFilepath); err != nil {
 		return nil, err
 	}
 	return &api, err
 }
 
-// ResolveReferences traverses the entire openapi struct tree and loads te h
-// TODO: this doesn't have to be public
-func (o *OpenAPI) ResolveReferences(absoluteBasePath string) error {
+// resolveReferences traverses the entire openapi struct tree and loads te h
+func (o *OpenAPI) resolveReferences(absoluteBasePath string) error {
 	o.SetBasePath(filepath.Dir(absoluteBasePath))
 	// TODO: what if JSON?
 	o, err := tree.Traverse(o, tree.ResolveRefs)
@@ -88,9 +87,8 @@ func (o *OpenAPI) ResolveReferences(absoluteBasePath string) error {
 	return nil
 }
 
-// LoadFromBytes loads the content into an OpenAPI struct. Extraneous functions that aid in this process should live here.A
-// TODO: this doesn't have to be public
-func (o *OpenAPI) LoadFromBytes(content []byte) error {
+// loadFromBytes loads the content into an OpenAPI struct. Extraneous functions that aid in this process should live here.A
+func (o *OpenAPI) loadFromBytes(content []byte) error {
 	err := yaml.Unmarshal(content, o)
 	if err != nil {
 		return fmt.Errorf("yaml unmarshalling error: %w", err)
@@ -99,8 +97,7 @@ func (o *OpenAPI) LoadFromBytes(content []byte) error {
 	return nil
 }
 
-// TODO: this doesn't have to be public
-func NewBaseOpenApi() OpenAPI {
+func newBaseOpenApi() OpenAPI {
 	return OpenAPI{
 		Node: tree.Node{},
 		Components: components.Components{

--- a/render/engine.go
+++ b/render/engine.go
@@ -17,7 +17,6 @@ import (
 )
 
 type EngineInterface interface {
-	With(config.Data) Engine
 	GetRenderer() Renderer
 	SetRenderer(renderer Renderer)
 	BuildRenderNode() tree.TraversalFunc
@@ -25,16 +24,14 @@ type EngineInterface interface {
 	render(data tree.NodeTraverser, templateFile string) ([]byte, error)
 }
 type Engine struct {
+	// renderer contains the object responsible for
 	renderer Renderer
 	config   config.Data
 }
 
 var _ EngineInterface = &Engine{}
 
-func NewEngine() *Engine {
-	return &Engine{}
-}
-func (e *Engine) With(config config.Data) Engine {
+func NewEngine(config config.Data) Engine {
 	return Engine{config: config}
 }
 
@@ -45,18 +42,26 @@ func (e *Engine) GetRenderer() Renderer {
 func (e *Engine) SetRenderer(r Renderer) {
 	e.renderer = r
 }
+
+// BuildRenderNode returns a function that fetches the appropriate template name and renders and the provided node to
+// disk.
+// TODO: This could simply be e.Render() as opposed to returning another function
 func (e *Engine) BuildRenderNode() tree.TraversalFunc {
 	return func(key string, parent, node tree.NodeTraverser) (tree.NodeTraverser, error) {
 		if s, ok := node.(*schema.Schema); ok {
+			// This allows us to avoid rendering schemas with these types
 			if s.Type != "object" && s.Type != "array" {
 				return node, nil
 			}
 		}
 
+		// find appropriate template name based on node provided
 		templateFile := GetTemplateFilename(node)
 		if templateFile == "" {
 			return node, nil
 		}
+
+		// render node and template into output ready to be written to disk
 		output, err := e.render(node, templateFile)
 		if err != nil {
 			return node, fmt.Errorf("could not render into %s: %w", templateFile, err)
@@ -88,21 +93,28 @@ func GetTemplateFilename(node tree.NodeTraverser) string {
 	return ""
 }
 
-// Render contains the parsing and rendering steps
+// Render contains the parsing and rendering steps. It parses a template, renders a node into it and applies any
+// required formatting.
 func (e *Engine) render(node tree.NodeTraverser, templateFilename string) ([]byte, error) {
-	r := e.GetRenderer()
+	renderer := e.GetRenderer()
 	templateDirectory := e.config.GetTemplateFilesDir()
-	parsedTemplate, err := r.ParseTemplate(templateFilename, templateDirectory)
+
+	// fetch appropriate template object
+	parsedTemplate, err := renderer.ParseTemplate(templateFilename, templateDirectory)
 	if err != nil {
 		return nil, err
 	}
-	renderedOutput, err := r.RenderToText(parsedTemplate, node)
+
+	// render the node and template to bytes
+	renderedOutput, err := renderer.RenderNode(parsedTemplate, node)
+	// TODO: this debug output could be moved into renderer.RenderNode
 	if config.Debug {
-		fmt.Printf("Rendering %s using %s\n", r.GetOutputFilename(node), templateFilename)
+		fmt.Printf("Rendering %s using %s\n", renderer.GetOutputFilename(node), templateFilename)
 		fmt.Println(string(renderedOutput))
 	}
+
 	// format code based on formatter provided by interface
-	formatted, err := r.Format(renderedOutput)
+	formatted, err := renderer.Format(renderedOutput)
 	if err != nil {
 		return nil, fmt.Errorf("could not format output: %w", err)
 	}

--- a/render/engine_test.go
+++ b/render/engine_test.go
@@ -40,7 +40,7 @@ func Test_Render_Render(t *testing.T) {
 	r.SetTemplateFuncMap(golang.DefaultFuncMap())
 	e := render.NewEngine(cfg)
 	e.SetRenderer(r)
-	_, err = tree.Traverse(test.OpenAPITree(), e.BuildRenderNode())
+	_, err = tree.Traverse(test.OpenAPITree(), e.Render)
 	if err != nil {
 		t.Errorf(err.Error())
 	}

--- a/render/engine_test.go
+++ b/render/engine_test.go
@@ -37,7 +37,7 @@ func Test_Render_Render(t *testing.T) {
 	cfg.OutputPath = tempFolder
 	r := &golang.Renderer{}
 	r.SetTemplateFuncMap(golang.DefaultFuncMap())
-	e := render.NewEngine().With(cfg)
+	e := render.NewEngine(cfg)
 	e.SetRenderer(r)
 	_, err = tree.Traverse(test.OpenAPITree(), e.BuildRenderNode())
 	if err != nil {
@@ -60,7 +60,7 @@ func TestEngineGetAndSetRenderer(t *testing.T) {
 func TestRender(t *testing.T) {
 	mockRenderer := render.MockRenderer{}
 	mockConfig := config.Data{OutputPath: "../templates"}
-	testEngine := render.NewEngine().With(mockConfig)
+	testEngine := render.NewEngine(mockConfig)
 	testEngine.SetRenderer(mockRenderer)
 
 	mockNode := &schema.Schema{Type: "object"}

--- a/render/engine_test.go
+++ b/render/engine_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"text/template"
 )
 
 func Test_Render_Render(t *testing.T) {
@@ -47,8 +48,66 @@ func Test_Render_Render(t *testing.T) {
 	// 	We're not currently rendering any 204 response schemas
 }
 
+func TestParseTemplate(t *testing.T) {
+	tests := []struct {
+		name              string
+		templateFilename  string
+		templateDirectory string
+		funcMap           *template.FuncMap
+		expectedErr       bool
+	}{
+		{
+			name:              "Valid Input",
+			templateFilename:  "openapi.tmpl",
+			templateDirectory: "../templates/go-client",
+			funcMap:           golang.DefaultFuncMap(),
+			expectedErr:       false,
+		},
+		{
+			name:              "Invalid Directory",
+			templateFilename:  "test.tmpl",
+			templateDirectory: "nonexistent_directory",
+			funcMap:           golang.DefaultFuncMap(),
+			expectedErr:       true,
+		},
+		{
+			name:              "Empty FuncMap",
+			templateFilename:  "test.tmpl",
+			templateDirectory: "../templates/go-client",
+			funcMap:           &template.FuncMap{},
+			expectedErr:       true,
+		},
+		{
+			name:              "Glob Error",
+			templateFilename:  "test.tmpl",
+			templateDirectory: "invalid_directory",
+			funcMap:           golang.DefaultFuncMap(),
+			expectedErr:       true,
+		},
+	}
+
+	// Create a Renderer instance
+
+	cfg := golang.NewGoClientTestConfig("../render/go/config_goclient_test.yml", "../openapi/test/fixtures/validation_no_refs.yaml")
+	err := cfg.Load()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	e := render.NewEngine(cfg)
+	e.SetRenderer(&golang.Renderer{})
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			e.GetRenderer().SetTemplateFuncMap(test.funcMap)
+			_, err := e.ParseTemplate(test.templateFilename, test.templateDirectory)
+			if (err != nil) != test.expectedErr {
+				t.Errorf("Expected error: %v, but got: %v", test.expectedErr, err)
+			}
+		})
+	}
+}
 func TestEngineGetAndSetRenderer(t *testing.T) {
-	mockRenderer := render.MockRenderer{}
+	mockRenderer := &render.MockRenderer{}
 	engine := render.Engine{}
 	engine.SetRenderer(mockRenderer)
 
@@ -58,10 +117,11 @@ func TestEngineGetAndSetRenderer(t *testing.T) {
 }
 
 func TestRender(t *testing.T) {
-	mockRenderer := render.MockRenderer{}
-	mockConfig := config.Data{OutputPath: "../templates"}
+	mockRenderer := &render.MockRenderer{}
+	mockConfig := config.Data{OutputPath: ".", TemplatesDir: "../../templates/go-client"}
 	testEngine := render.NewEngine(mockConfig)
 	testEngine.SetRenderer(mockRenderer)
+	mockRenderer.SetTemplateFuncMap(golang.DefaultFuncMap())
 
 	mockNode := &schema.Schema{Type: "object"}
 	mockParentNode := &parameter.Parameter{}

--- a/render/engine_test.go
+++ b/render/engine_test.go
@@ -30,17 +30,13 @@ func Test_Render_Render(t *testing.T) {
 	}(tempFolder)
 
 	// TODO test this in a language agnostic way or move to E2E testing suite
-	cfg := golang.NewGinServerTestConfig("../render/go/config_goginserver_test.yml", "../openapi/test/fixtures/validation_no_refs.yaml")
-	err := cfg.Load()
-	if err != nil {
-		t.Errorf(err.Error())
-	}
+	cfg := golang.MustLoadGinServerTestConfig("../render/go/config_goginserver_test.yml", "../openapi/test/fixtures/validation_no_refs.yaml")
 	cfg.OutputPath = tempFolder
 	r := &golang.Renderer{}
 	r.SetTemplateFuncMap(golang.DefaultFuncMap())
 	e := render.NewEngine(cfg)
 	e.SetRenderer(r)
-	_, err = tree.Traverse(test.OpenAPITree(), e.Render)
+	_, err := tree.Traverse(test.OpenAPITree(), e.Render)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -88,11 +84,7 @@ func TestParseTemplate(t *testing.T) {
 
 	// Create a Renderer instance
 
-	cfg := golang.NewGoClientTestConfig("../render/go/config_goclient_test.yml", "../openapi/test/fixtures/validation_no_refs.yaml")
-	err := cfg.Load()
-	if err != nil {
-		t.Errorf(err.Error())
-	}
+	cfg := golang.MustLoadGoClientTestConfig("../render/go/config_goclient_test.yml", "../openapi/test/fixtures/validation_no_refs.yaml")
 	e := render.NewEngine(cfg)
 	e.SetRenderer(&golang.Renderer{})
 

--- a/render/go/renderer.go
+++ b/render/go/renderer.go
@@ -192,27 +192,34 @@ func ToTitle(s string) (ret string) {
 	return ret
 }
 
-func NewGinServerTestConfig(configPath, openAPIPath string) config.Data {
-	// TODO: `Must` this function and load the returned config before returning it
+func MustLoadGinServerTestConfig(configPath, openAPIPath string) config.Data {
 	config.ConfigFilePath = configPath
 	config.Debug = true
-	return config.Data{
+	c := config.Data{
 		Template: config.Template{
 			Name: "go-gin",
 		},
 		OpenAPIFile: openAPIPath,
 		OutputPath:  ".",
 	}
+	if err := c.Load(); err != nil {
+		panic(err)
+	}
+	return c
 }
-func NewGoClientTestConfig(configPath, openAPIPath string) config.Data {
+func MustLoadGoClientTestConfig(configPath, openAPIPath string) config.Data {
 	// TODO: `Must` this function and load the returned config before returning it
 	config.ConfigFilePath = configPath
 	config.Debug = true
-	return config.Data{
+	c := config.Data{
 		Template: config.Template{
 			Name: "go-client",
 		},
 		OpenAPIFile: openAPIPath,
 		OutputPath:  ".",
 	}
+	if err := c.Load(); err != nil {
+		panic(err)
+	}
+	return c
 }

--- a/render/go/renderer.go
+++ b/render/go/renderer.go
@@ -25,15 +25,6 @@ type Renderer struct {
 	funcMap *template.FuncMap
 }
 
-// ParseTemplate reads the given template and returns a template object with the appropriate function map applied.
-func (g *Renderer) ParseTemplate(templateFilename, templateDirectory string) (*template.Template, error) {
-	// TODO: This may very well be the same implementation for all languages. Consider moving to engine struct
-	templater := template.New(templateFilename)
-	funcMap := g.GetTemplateFuncMap()
-	templater.Funcs(*funcMap)
-	return templater.ParseGlob(fmt.Sprintf("%s/*.tmpl", templateDirectory))
-}
-
 // RenderNode writes the relevant information contained within an openapi node into the provided template and returns
 // the result.
 func (g *Renderer) RenderNode(parsedTemplate *template.Template, node tree.NodeTraverser) ([]byte, error) {
@@ -202,6 +193,7 @@ func ToTitle(s string) (ret string) {
 }
 
 func NewGinServerTestConfig(configPath, openAPIPath string) config.Data {
+	// TODO: `Must` this function and load the returned config before returning it
 	config.ConfigFilePath = configPath
 	config.Debug = true
 	return config.Data{
@@ -213,6 +205,7 @@ func NewGinServerTestConfig(configPath, openAPIPath string) config.Data {
 	}
 }
 func NewGoClientTestConfig(configPath, openAPIPath string) config.Data {
+	// TODO: `Must` this function and load the returned config before returning it
 	config.ConfigFilePath = configPath
 	config.Debug = true
 	return config.Data{

--- a/render/go/renderer_test.go
+++ b/render/go/renderer_test.go
@@ -215,58 +215,6 @@ func TestGolang_ToTitle(t *testing.T) {
 	}
 }
 
-func TestParseTemplate(t *testing.T) {
-	tests := []struct {
-		name              string
-		templateFilename  string
-		templateDirectory string
-		funcMap           *template.FuncMap
-		expectedErr       bool
-	}{
-		{
-			name:              "Valid Input",
-			templateFilename:  "openapi.tmpl",
-			templateDirectory: "../../templates/go-client",
-			funcMap:           golang.DefaultFuncMap(),
-			expectedErr:       false,
-		},
-		{
-			name:              "Invalid Directory",
-			templateFilename:  "test.tmpl",
-			templateDirectory: "nonexistent_directory",
-			funcMap:           golang.DefaultFuncMap(),
-			expectedErr:       true,
-		},
-		{
-			name:              "Empty FuncMap",
-			templateFilename:  "test.tmpl",
-			templateDirectory: "../../templates/go-client",
-			funcMap:           &template.FuncMap{},
-			expectedErr:       true,
-		},
-		{
-			name:              "Glob Error",
-			templateFilename:  "test.tmpl",
-			templateDirectory: "invalid_directory",
-			funcMap:           golang.DefaultFuncMap(),
-			expectedErr:       true,
-		},
-	}
-
-	// Create a Renderer instance
-	r := &golang.Renderer{}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			r.SetTemplateFuncMap(test.funcMap)
-			_, err := r.ParseTemplate(test.templateFilename, test.templateDirectory)
-			if (err != nil) != test.expectedErr {
-				t.Errorf("Expected error: %v, but got: %v", test.expectedErr, err)
-			}
-		})
-	}
-}
-
 func TestRenderToText(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/render/go/renderer_test.go
+++ b/render/go/renderer_test.go
@@ -303,7 +303,7 @@ func TestRenderToText(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			output, err := r.RenderToText(test.parsedTemplate, test.node)
+			output, err := r.RenderNode(test.parsedTemplate, test.node)
 			if (err != nil) != test.expectedErr {
 				t.Errorf("Expected error: %v, but got: %v", test.expectedErr, err)
 			}

--- a/render/mock_renderer.go
+++ b/render/mock_renderer.go
@@ -22,7 +22,7 @@ func (mr MockRenderer) ParseTemplate(filename, directory string) (*template.Temp
 	return template.New(filename), nil
 }
 
-func (mr MockRenderer) RenderToText(template *template.Template, traverser tree.NodeTraverser) ([]byte, error) {
+func (mr MockRenderer) RenderNode(template *template.Template, traverser tree.NodeTraverser) ([]byte, error) {
 	return []byte("rendered_output"), nil
 }
 

--- a/render/mock_renderer.go
+++ b/render/mock_renderer.go
@@ -6,30 +6,29 @@ import (
 )
 
 // MockRenderer is a mock implementation of the Renderer interface for testing.
-type MockRenderer struct{}
+type MockRenderer struct {
+	funcMap *template.FuncMap
+}
 
-var _ Renderer = MockRenderer{}
+var _ Renderer = &MockRenderer{}
 
-func (mr MockRenderer) SetTemplateFuncMap(funcMap *template.FuncMap) {
+func (mr *MockRenderer) SetTemplateFuncMap(funcMap *template.FuncMap) {
+	mr.funcMap = funcMap
 	return
 }
 
-func (mr MockRenderer) GetTemplateFuncMap() *template.FuncMap {
-	return &template.FuncMap{}
+func (mr *MockRenderer) GetTemplateFuncMap() *template.FuncMap {
+	return mr.funcMap
 }
 
-func (mr MockRenderer) ParseTemplate(filename, directory string) (*template.Template, error) {
-	return template.New(filename), nil
-}
-
-func (mr MockRenderer) RenderNode(template *template.Template, traverser tree.NodeTraverser) ([]byte, error) {
+func (mr *MockRenderer) RenderNode(template *template.Template, traverser tree.NodeTraverser) ([]byte, error) {
 	return []byte("rendered_output"), nil
 }
 
-func (mr MockRenderer) GetOutputFilename(node tree.NodeTraverser) string {
+func (mr *MockRenderer) GetOutputFilename(node tree.NodeTraverser) string {
 	return "output_filename"
 }
 
-func (mr MockRenderer) Format(output []byte) ([]byte, error) {
+func (mr *MockRenderer) Format(output []byte) ([]byte, error) {
 	return output, nil
 }

--- a/render/render.go
+++ b/render/render.go
@@ -11,5 +11,5 @@ type Renderer interface {
 	GetTemplateFuncMap() *template.FuncMap
 	Format([]byte) ([]byte, error)
 	ParseTemplate(string, string) (*template.Template, error)
-	RenderToText(*template.Template, tree.NodeTraverser) ([]byte, error)
+	RenderNode(*template.Template, tree.NodeTraverser) ([]byte, error)
 }

--- a/render/render.go
+++ b/render/render.go
@@ -10,6 +10,5 @@ type Renderer interface {
 	SetTemplateFuncMap(*template.FuncMap)
 	GetTemplateFuncMap() *template.FuncMap
 	Format([]byte) ([]byte, error)
-	ParseTemplate(string, string) (*template.Template, error)
 	RenderNode(*template.Template, tree.NodeTraverser) ([]byte, error)
 }

--- a/test/render_e2e_test.go
+++ b/test/render_e2e_test.go
@@ -23,11 +23,7 @@ func TestGolang_GinServer_Renderer(t *testing.T) {
 		}
 	}(tempFolder)
 
-	cfg := golang.NewGinServerTestConfig("../render/go/config_goginserver_test.yml", "../openapi/test/fixtures/validation_no_refs.yaml")
-	err := cfg.Load()
-	if err != nil {
-		t.Errorf(err.Error())
-	}
+	cfg := golang.MustLoadGinServerTestConfig("../render/go/config_goginserver_test.yml", "../openapi/test/fixtures/validation_no_refs.yaml")
 	cfg.OutputPath = tempFolder
 	r := golang.Renderer{}
 	r.SetTemplateFuncMap(golang.DefaultFuncMap())
@@ -58,11 +54,7 @@ func TestGolang_GoClient_Renderer(t *testing.T) {
 		}
 	}(tempFolder)
 
-	cfg := golang.NewGoClientTestConfig("../render/go/config_goclient_test.yml", "../openapi/test/fixtures/validation_no_refs.yaml")
-	err := cfg.Load()
-	if err != nil {
-		t.Errorf(err.Error())
-	}
+	cfg := golang.MustLoadGoClientTestConfig("../render/go/config_goclient_test.yml", "../openapi/test/fixtures/validation_no_refs.yaml")
 	cfg.OutputPath = tempFolder
 	r := golang.Renderer{}
 	r.SetTemplateFuncMap(golang.DefaultFuncMap())
@@ -106,10 +98,7 @@ func TestGolang_GoClient_Renderer_HeavyNesting(t *testing.T) {
 			t.Errorf(err.Error())
 		}
 	}(tempFolder)
-	cfg := golang.NewGoClientTestConfig("../render/go/config_goclient_test.yml", "../openapi/test/fixtures/validation_no_refs.yaml")
-	if err := cfg.Load(); err != nil {
-		t.Error(err)
-	}
+	cfg := golang.MustLoadGoClientTestConfig("../render/go/config_goclient_test.yml", "../openapi/test/fixtures/validation_no_refs.yaml")
 	cfg.OpenAPIFile = "test/fixtures/heavy_nesting.yaml"
 	cfg.OutputPath = tempFolder
 	r := golang.Renderer{}
@@ -153,10 +142,7 @@ func TestGolang_GoGin_Renderer_HeavyNesting(t *testing.T) {
 			t.Errorf(err.Error())
 		}
 	}(tempFolder)
-	cfg := golang.NewGinServerTestConfig("../render/go/config_goginserver_test.yml", "../openapi/test/fixtures/validation_no_refs.yaml")
-	if err := cfg.Load(); err != nil {
-		t.Error(err)
-	}
+	cfg := golang.MustLoadGinServerTestConfig("../render/go/config_goginserver_test.yml", "../openapi/test/fixtures/validation_no_refs.yaml")
 	cfg.OpenAPIFile = "test/fixtures/heavy_nesting.yaml"
 	cfg.OutputPath = tempFolder
 	r := golang.Renderer{}
@@ -201,11 +187,7 @@ func TestRegression_GoClient_EmptyRequestAndResponseBodiesShouldRender(t *testin
 		}
 	}(tempFolder)
 
-	cfg := golang.NewGoClientTestConfig("fixtures/regressions/empty_bodies/config_goclient_empty_bodies.yml", "fixtures/regressions/empty_bodies/empty_bodies.yml")
-	err := cfg.Load()
-	if err != nil {
-		t.Errorf(err.Error())
-	}
+	cfg := golang.MustLoadGoClientTestConfig("fixtures/regressions/empty_bodies/config_goclient_empty_bodies.yml", "fixtures/regressions/empty_bodies/empty_bodies.yml")
 	cfg.OutputPath = tempFolder
 	r := golang.Renderer{}
 	r.SetTemplateFuncMap(golang.DefaultFuncMap())
@@ -290,11 +272,7 @@ func TestRegression_GoGin_EmptyRequestAndResponseBodiesShouldRender(t *testing.T
 		}
 	}(tempFolder)
 
-	cfg := golang.NewGinServerTestConfig("fixtures/regressions/empty_bodies/config_goclient_empty_bodies.yml", "fixtures/regressions/empty_bodies/empty_bodies.yml")
-	err := cfg.Load()
-	if err != nil {
-		t.Errorf(err.Error())
-	}
+	cfg := golang.MustLoadGinServerTestConfig("fixtures/regressions/empty_bodies/config_goclient_empty_bodies.yml", "fixtures/regressions/empty_bodies/empty_bodies.yml")
 	cfg.OutputPath = tempFolder
 	r := golang.Renderer{}
 	r.SetTemplateFuncMap(golang.DefaultFuncMap())

--- a/test/render_e2e_test.go
+++ b/test/render_e2e_test.go
@@ -43,7 +43,7 @@ func TestGolang_GinServer_Renderer(t *testing.T) {
 	apiTree.SetMetadata(tree.Metadata{
 		"package": cfg.Template.BasePackageName,
 	})
-	_, err = tree.Traverse(apiTree, e.BuildRenderNode())
+	_, err = tree.Traverse(apiTree, e.Render)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -78,7 +78,7 @@ func TestGolang_GoClient_Renderer(t *testing.T) {
 	apiTree.SetMetadata(tree.Metadata{
 		"package": cfg.Template.BasePackageName,
 	})
-	_, err = tree.Traverse(apiTree, e.BuildRenderNode())
+	_, err = tree.Traverse(apiTree, e.Render)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -126,7 +126,7 @@ func TestGolang_GoClient_Renderer_HeavyNesting(t *testing.T) {
 	apiTree.SetMetadata(tree.Metadata{
 		"package": cfg.Template.BasePackageName,
 	})
-	if _, err := tree.Traverse(apiTree, e.BuildRenderNode()); err != nil {
+	if _, err := tree.Traverse(apiTree, e.Render); err != nil {
 		t.Error(err)
 	}
 	if err := filepath.Walk(tempFolder, assertFilesPresent(tempFolder, heavyNestingFilenames)); err != nil {
@@ -173,7 +173,7 @@ func TestGolang_GoGin_Renderer_HeavyNesting(t *testing.T) {
 	apiTree.SetMetadata(tree.Metadata{
 		"package": cfg.Template.BasePackageName,
 	})
-	if _, err := tree.Traverse(apiTree, e.BuildRenderNode()); err != nil {
+	if _, err := tree.Traverse(apiTree, e.Render); err != nil {
 		t.Error(err)
 	}
 	if err := filepath.Walk(tempFolder, assertFilesPresent(tempFolder, heavyNestingFilenames)); err != nil {
@@ -219,7 +219,7 @@ func TestRegression_GoClient_EmptyRequestAndResponseBodiesShouldRender(t *testin
 	api.SetMetadata(tree.Metadata{
 		"package": cfg.Template.BasePackageName,
 	})
-	_, err = tree.Traverse(api, e.BuildRenderNode())
+	_, err = tree.Traverse(api, e.Render)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -308,7 +308,7 @@ func TestRegression_GoGin_EmptyRequestAndResponseBodiesShouldRender(t *testing.T
 	api.SetMetadata(tree.Metadata{
 		"package": cfg.Template.BasePackageName,
 	})
-	_, err = tree.Traverse(api, e.BuildRenderNode())
+	_, err = tree.Traverse(api, e.Render)
 	if err != nil {
 		t.Errorf(err.Error())
 	}

--- a/test/render_e2e_test.go
+++ b/test/render_e2e_test.go
@@ -31,7 +31,7 @@ func TestGolang_GinServer_Renderer(t *testing.T) {
 	cfg.OutputPath = tempFolder
 	r := golang.Renderer{}
 	r.SetTemplateFuncMap(golang.DefaultFuncMap())
-	e := render.NewEngine().With(cfg)
+	e := render.NewEngine(cfg)
 	e.SetRenderer(&r)
 
 	// We have to pop the first element off the path constant
@@ -66,7 +66,7 @@ func TestGolang_GoClient_Renderer(t *testing.T) {
 	cfg.OutputPath = tempFolder
 	r := golang.Renderer{}
 	r.SetTemplateFuncMap(golang.DefaultFuncMap())
-	e := render.NewEngine().With(cfg)
+	e := render.NewEngine(cfg)
 	e.SetRenderer(&r)
 
 	// We have to pop the first element off the path constant
@@ -114,7 +114,7 @@ func TestGolang_GoClient_Renderer_HeavyNesting(t *testing.T) {
 	cfg.OutputPath = tempFolder
 	r := golang.Renderer{}
 	r.SetTemplateFuncMap(golang.DefaultFuncMap())
-	e := render.NewEngine().With(cfg)
+	e := render.NewEngine(cfg)
 	e.SetRenderer(&r)
 
 	// We have to pop the first element off the path constant
@@ -161,7 +161,7 @@ func TestGolang_GoGin_Renderer_HeavyNesting(t *testing.T) {
 	cfg.OutputPath = tempFolder
 	r := golang.Renderer{}
 	r.SetTemplateFuncMap(golang.DefaultFuncMap())
-	e := render.NewEngine().With(cfg)
+	e := render.NewEngine(cfg)
 	e.SetRenderer(&r)
 
 	// We have to pop the first element off the path constant
@@ -209,7 +209,7 @@ func TestRegression_GoClient_EmptyRequestAndResponseBodiesShouldRender(t *testin
 	cfg.OutputPath = tempFolder
 	r := golang.Renderer{}
 	r.SetTemplateFuncMap(golang.DefaultFuncMap())
-	e := render.NewEngine().With(cfg)
+	e := render.NewEngine(cfg)
 	e.SetRenderer(&r)
 	api, err := openapi.LoadFromYaml(cfg.OpenAPIFile)
 	if err != nil {
@@ -298,7 +298,7 @@ func TestRegression_GoGin_EmptyRequestAndResponseBodiesShouldRender(t *testing.T
 	cfg.OutputPath = tempFolder
 	r := golang.Renderer{}
 	r.SetTemplateFuncMap(golang.DefaultFuncMap())
-	e := render.NewEngine().With(cfg)
+	e := render.NewEngine(cfg)
 	e.SetRenderer(&r)
 	api, err := openapi.LoadFromYaml(cfg.OpenAPIFile)
 	if err != nil {

--- a/tree/refs.go
+++ b/tree/refs.go
@@ -20,6 +20,7 @@ func readRef(absFilename string, n NodeTraverser) error {
 		return fmt.Errorf("unable to resolve Reference: %w", err)
 	}
 
+	// TODO: What if JSON?
 	err = yaml.Unmarshal(content, n)
 	if err != nil {
 		return fmt.Errorf("unable to unmarshal reference file:\n%w", err)


### PR DESCRIPTION
- GetTemplateFilesDir() still needs some work. This can either happen here or in a followup
- Make methods private that don't need to be public
- Remove redundant closure
- Move parsing of templates into the engine, previously in renderer
- Make main musty
- Make test config constructors musty
- Add documentation and address review notes from previous PR